### PR TITLE
BUGFIX: set a recipient for Approval Email

### DIFF
--- a/code/MemberProfilePage.php
+++ b/code/MemberProfilePage.php
@@ -747,22 +747,23 @@ class MemberProfilePage_Controller extends Page_Controller {
 			}
 
 			if ($emails) {
-				$email   = new Email();
-				$config  = SiteConfig::current_site_config();
-				$approve = Controller::join_links(
-					Director::baseURL(), 'member-approval', $member->ID, '?token=' . $member->ValidationKey
-				);
-
-				$email->setSubject("Registration Approval Requested for $config->Title");
-				$email->setBcc(implode(',', array_unique($emails)));
-				$email->setTemplate('MemberRequiresApprovalEmail');
-				$email->populateTemplate(array(
-					'SiteConfig'  => $config,
-					'Member'      => $member,
-					'ApproveLink' => Director::absoluteURL($approve)
-				));
-
-				$email->send();
+				foreach(array_unique($emails) as $uniqueemail) {
+					$email   = new Email();
+					$config  = SiteConfig::current_site_config();
+					$approve = Controller::join_links(
+						Director::baseURL(), 'member-approval', $member->ID, '?token=' . $member->ValidationKey
+					);
+	
+					$email->setTo($uniqueemail);
+					$email->setSubject("Registration Approval Requested for $config->Title");
+					$email->setTemplate('MemberRequiresApprovalEmail');
+					$email->populateTemplate(array(
+						'SiteConfig'  => $config,
+						'Member'      => $member,
+						'ApproveLink' => Director::absoluteURL($approve)
+					));
+					$email->send();
+				}
 			}
 		} elseif($this->EmailType != 'None') {
 			$email = new MemberConfirmationEmail($this, $member);


### PR DESCRIPTION
smtpmailer requires a valid recipient address and not just a list of bcc addressees
