### PR TITLE
Make error messages for account confirmation less confusing

### DIFF
--- a/code/MemberProfilePage.php
+++ b/code/MemberProfilePage.php
@@ -693,12 +693,11 @@ class MemberProfilePage_Controller extends Page_Controller {
 			));
 		}
 		
-		if(!$member->NeedsValidation)
-		{
+		if(!$member->NeedsValidation) {
 			// Already approved
 			return array(
 				'Title' => _t('MemberProfiles.ALREADYAPPROVED', 'Already Approved'),
-				'Content' => _t('MemberProfiles.ALREADYAPPROVEDNOTE', '<p>This member has already been approved</p>'));
+				'Content' => '<p>' . _t('MemberProfiles.ALREADYAPPROVEDNOTE', 'This member has already been approved') . '</p>');
 		}
 
 		if($member->ValidationKey != $key || !$member->NeedsValidation) {

--- a/code/MemberProfilePage.php
+++ b/code/MemberProfilePage.php
@@ -677,19 +677,28 @@ class MemberProfilePage_Controller extends Page_Controller {
 	 * @return array
 	 */
 	public function confirm($request) {
-		if(Member::currentUser()) {
-			return Security::permissionFailure ($this, _t (
-				'MemberProfiles.CANNOTCONFIRMLOGGEDIN',
-				'You cannot confirm account while you are logged in.'
-			));
-		}
-
 		if (
 			$this->EmailType != 'Validation'
 			|| (!$id = $request->param('ID')) || (!$key = $request->getVar('key')) || !is_numeric($id)
 			|| !$member = DataObject::get_by_id('Member', $id)
 		) {
 			$this->httpError(404);
+		}
+		
+		$currMember = Member::currentUser();
+		if($currMember && $currMember->ID != $member->ID) {
+			return Security::permissionFailure ($this, _t (
+				'MemberProfiles.CANNOTCONFIRMLOGGEDIN',
+				'You cannot confirm account while you are logged in.'
+			));
+		}
+		
+		if(!$member->NeedsValidation)
+		{
+			// Already approved
+			return array(
+				'Title' => _t('MemberProfiles.ALREADYAPPROVED', 'Already Approved'),
+				'Content' => _t('MemberProfiles.ALREADYAPPROVEDNOTE', '<p>This member has already been approved</p>'));
 		}
 
 		if($member->ValidationKey != $key || !$member->NeedsValidation) {


### PR DESCRIPTION
This patch does the following:
- Shows an "already confirmed" message if the account has already been confirmed
- If the user is already logged in and is attempting to confirm their own account, then the "already confirmed" message is shown. If the user doesn't match the account being validated, then the original error message is shown

NOTE: This only applies to the 0.5 branch (for SS 2.4 users); as far as I can tell, the master branch doesn't have this problem.
