### PR TITLE
make RegisterForm work with spam protection:

### DIFF
--- a/code/MemberProfilePage.php
+++ b/code/MemberProfilePage.php
@@ -490,7 +490,7 @@ class MemberProfilePage_Controller extends Page_Controller {
 		);
 
 		if(class_exists('SpamProtectorManager')) {
-			SpamProtectorManager::update_form($form);
+			$form->enableSpamProtection();
 		}
 		$this->extend('updateRegisterForm', $form);
 		return $form;

--- a/templates/Layout/MemberProfilePage_profile.ss
+++ b/templates/Layout/MemberProfilePage_profile.ss
@@ -1,6 +1,6 @@
-<div class="content-container typography>">
+<div class="content-container typography">
 	<h1>$Title</h1>
-	
+
 	<div class="content">
 		$Content
 

--- a/templates/Layout/MemberProfileViewer_view.ss
+++ b/templates/Layout/MemberProfileViewer_view.ss
@@ -1,8 +1,8 @@
 <% require css(memberprofiles/css/MemberProfileViewer.css) %>
 
-<div class="content-container typography>">
+<div class="content-container typography">
 	<h1>$Title</h1>
-	
+
 	<div class="content member-profile <% if IsSelf %>member-profile-self<% end_if %>">
 		<% if IsSelf %>
 			<p class="message"><%t MemberProfiles.THISISYOURPROFILE 'This is your profile!' %> <a href="$Parent.Link"><%t MemberProfiles.EDITPROFILE 'Edit Profile' %></a></p>


### PR DESCRIPTION
I noticed this:

[User Deprecated] SpamProtectorManager::update_form is deprecated. SpamProtectorManager::update_form is deprecatedPlease use $form->enableSpamProtection() for adding spamprotection. Called from MemberProfilePage_Controller->RegisterForm.
