### PR TITLE
Update MemberProfilePage.php

### DIFF
--- a/code/MemberProfilePage.php
+++ b/code/MemberProfilePage.php
@@ -772,7 +772,7 @@ class MemberProfilePage_Controller extends Page_Controller {
 
 			if ($groups) foreach ($groups as $group) {
 				foreach ($group->Members() as $_member) {
-					if ($member->Email) $emails[] = $_member->Email;
+					if ($_member->Email) $emails[] = $_member->Email;
 				}
 			}
 


### PR DESCRIPTION
Typo.This condition should check if Email is set for $_member rather than $member. Other wise if member($member) being added, has 'Email' set, approval email would fire for all group members ($_members) , even for members without Emails set.
