### PR TITLE
FIX: Duplicating email confirmation link

### DIFF
--- a/code/email/MemberConfirmationEmail.php
+++ b/code/email/MemberConfirmationEmail.php
@@ -107,12 +107,11 @@ class MemberConfirmationEmail extends Email {
 		$variables = array (
 			'$SiteName'       => SiteConfig::current_site_config()->Title,
 			'$LoginLink'      => Controller::join_links(
-				$absoluteBaseURL, 
+				$absoluteBaseURL,
 				singleton('Security')->Link('login')
 			),
 			'$ConfirmLink'    => Controller::join_links(
-				$absoluteBaseURL,
-				$this->page->Link('confirm'),
+				$this->page->AbsoluteLink('confirm'),
 				$this->member->ID,
 				"?key={$this->member->ValidationKey}"
 			),


### PR DESCRIPTION
Fixed the link in the member registration confirmation email. No longer creates a link with duplicate segments.

See #140 

Note: First time doing a PR, please let me know if I've done something wrong.