### PR TITLE
Fix(yml) change yml block name from routes to memberprofilesroutes

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -1,5 +1,5 @@
 ---
-Name: routes
+Name: memberprofilesroutes
 After: framework/routes#coreroutes
 ---
 SilverStripe\Control\Director:


### PR DESCRIPTION
SilverStripe's yml name blocks must be unique, 'routes' is very generic and clashes with other modules.
Annoyingly this will require a major version bump as anyone overriding this block will need to update their configuration.