### PR TITLE
FIX: 4.3.0 causes the page in the CMS to throw an exception.

### DIFF
--- a/src/Pages/MemberProfilePage.php
+++ b/src/Pages/MemberProfilePage.php
@@ -7,7 +7,6 @@ use Symbiote\MemberProfiles\Forms\MemberProfilesAddSectionAction;
 use Symbiote\MemberProfiles\Email\MemberConfirmationEmail;
 use Symbiote\MemberProfiles\Model\MemberProfileFieldsSection;
 use Symbiote\MemberProfiles\Model\MemberProfileField;
-use Symbiote\MemberProfiles\Model\MemberProfileSection;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 use UndefinedOffset\SortableGridField\Forms\GridFieldSortableRows;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
@@ -66,7 +65,6 @@ use SilverStripe\ORM\ValidationResult;
  * @property string $ConfirmationContent
  * @property int $PostRegistrationTargetID
  * @method \SilverStripe\CMS\Model\SiteTree PostRegistrationTarget()
- * @method \SilverStripe\ORM\DataList|\Symbiote\MemberProfiles\Model\MemberProfileSection[] Sections()
  * @method \SilverStripe\ORM\DataList|\SilverStripe\Security\Group[] Groups()
  * @method \SilverStripe\ORM\DataList|\SilverStripe\Security\Group[] SelectableGroups()
  * @method \SilverStripe\ORM\DataList|\SilverStripe\Security\Group[] ApprovalGroups()
@@ -101,7 +99,7 @@ class MemberProfilePage extends Page
 
     private static $has_many = array (
         'Fields'   => MemberProfileField::class,
-        'Sections' => MemberProfileSection::class
+        'Sections' => MemberProfileFieldsSection::class
     );
 
     private static $owns = array(

--- a/src/Pages/MemberProfilePageController.php
+++ b/src/Pages/MemberProfilePageController.php
@@ -55,7 +55,6 @@ use Symbiote\MemberProfiles\Forms\MemberProfileValidator;
  * @property int $PostRegistrationTargetID
  * @method \SilverStripe\CMS\Model\SiteTree PostRegistrationTarget()
  * @method \SilverStripe\ORM\DataList|\Symbiote\MemberProfiles\Model\MemberProfileField[] Fields()
- * @method \SilverStripe\ORM\DataList|\Symbiote\MemberProfiles\Model\MemberProfileSection[] Sections()
  * @method \SilverStripe\ORM\DataList|\SilverStripe\Security\Group[] Groups()
  * @method \SilverStripe\ORM\DataList|\SilverStripe\Security\Group[] SelectableGroups()
  * @method \SilverStripe\ORM\DataList|\SilverStripe\Security\Group[] ApprovalGroups()


### PR DESCRIPTION
This is because the relationship is looking at the wrong class.

I encountered this when testing https://github.com/symbiote/silverstripe-memberprofiles/issues/147, but it looks like everything worked fine in 4.2.X. I've tested this before and after the change (comparing 4.3.0 to 4.2.X) and I can't see any differences here. We're basically telling it to look at the correct class for the relationship (since that's what's actually being used down here https://github.com/symbiote/silverstripe-memberprofiles/blob/master/src/Pages/MemberProfilePage.php#L447).