### PR TITLE
Provide Member's unique_identifier_field to the password validator

### DIFF
--- a/src/Forms/MemberProfileValidator.php
+++ b/src/Forms/MemberProfileValidator.php
@@ -113,6 +113,12 @@ class MemberProfileValidator extends RequiredFields
         if (isset($data['Password']) && $data['Password'] !== "") {
             if (is_null($member)) {
                 $member = Member::create();
+
+                //pass in the Unique Identifier Field (usually Email)
+                $idField = Member::config()->get('unique_identifier_field');
+                if(isset($data[$idField])) {
+                    $member->$idField = $data[$idField];
+                }
             }
 
             if ($validator = $member::password_validator()) {


### PR DESCRIPTION
I'm setting up the module to use Troy Hunt's HaveIBeenPwned service on member registration. One of the endpoints is a check on whether the email address appears in a breach; however, Member Profiles doesn't pass this information into the validator.

Member accounts are never going to exist unless the unique_identifier_field (usually Email) is set, so I've tweaked the password validator to include this information if it's present. 