### PR TITLE
FIX: ChangePasswordField toogle method, fixes #163

### DIFF
--- a/client/javascript/ConfirmedPasswordField.js
+++ b/client/javascript/ConfirmedPasswordField.js
@@ -5,10 +5,9 @@
     var $container = $('.showOnClickContainer', $(this).parent());
 
     $container.toggle('fast', function() {
-      $container.find('input[type="hidden"]').val($container.is(":visible") ? 1 : 0);
+      $container.toggleClass("d-none").find('input[type="hidden"]').val($container.hasClass("d-none")?0:1);
     });
 
     return false;
-  })
-  .find(".confirmedpassword .showOnClickContainer").hide();
+  });
 })(jQuery);


### PR DESCRIPTION
When using the ConfirmPasswordField, the `Change Password` link is not toggling the password field.

The reason is that this field was not intended to be used outside the admin, which is why the toggle logic is not included in the field but in the admin bundle.js.

In order to port the toggling to the frontend, the required js was copied into a separate JS file and required in the MemberProfilePageController.

When Silverstripe 4 switched from toggling this field via inline style to css class `d-none`, the JS copy was not updated to reflect this change.

Please consider the attached MR, fixes #163.

Thanks from across the ditch.